### PR TITLE
Fix pack asset paths after repo restructure

### DIFF
--- a/src/Plumber/Plumber.csproj
+++ b/src/Plumber/Plumber.csproj
@@ -42,15 +42,15 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Include="..\images\plumber.png">
+		<None Include="..\..\images\plumber.png">
 			<Pack>True</Pack>
 			<PackagePath>\</PackagePath>
 		</None>
-		<None Include="..\README.md">
+		<None Include="..\..\readme.md">
 			<Pack>True</Pack>
-			<PackagePath>\</PackagePath>
+			<PackagePath>README.md</PackagePath>
 		</None>
-		<None Include="..\LICENSE">
+		<None Include="..\..\LICENSE">
 			<Pack>True</Pack>
 			<PackagePath>\</PackagePath>
 		</None>


### PR DESCRIPTION
## Summary
The publish pipeline failed at `dotnet pack` for 3.1.0:

```
error : Could not find a part of the path '/home/runner/work/plumber/plumber/src/images'
```

Commit 133302a moved the project to `src/Plumber/`, but the packed asset includes in `Plumber.csproj` still pointed one level too shallow (`..\images\plumber.png` resolves to `src/images/`). Fixed all three includes to go up two levels.

Also fixed a latent case bug: the file on disk is `readme.md` but the project packed `README.md` — invisible on Windows, fatal on the Linux runner. The include now references `readme.md` and renames it to `README.md` via `PackagePath` so `PackageReadmeFile` still matches.

## Verification
Local `dotnet pack -c Release --no-restore -p:PackageVersion=3.1.0` succeeds; the nupkg contains `LICENSE`, `plumber.png`, and `README.md` at the package root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
